### PR TITLE
Fix ssh client version retrieval

### DIFF
--- a/lib/facter/ssh_client_version.rb
+++ b/lib/facter/ssh_client_version.rb
@@ -1,6 +1,7 @@
 Facter.add("ssh_client_version_full") do
   setcode do
-    version = Facter::Util::Resolution.exec('sshd -V 2>&1').
+    version = Facter::Util::Resolution.exec('ssh -V 2>&1').
+      to_s.
       lines.
       to_a.
       select { |line| line.match(/^OpenSSH_/) }.


### PR DESCRIPTION
Current implementation of the code which gets the version of SSH client
actually checks the version of SSH server assuming they are equal.

If SSH server is not installed then the code crashes.

This patch does not rely on SSH server to be installed and avoids
throwing an unhandled exception in case SSH client is also not
installed.

Closes-Bug: #1494309
