### PR TITLE
hiera match_block not working if ssh::server is called directly

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -5,10 +5,20 @@ class ssh::server(
   $validate_sshd_file   = false,
   $use_augeas           = false,
   $options_absent       = [],
+  $match_block          = {},
 ) inherits ssh::params {
+
+  validate_hash($match_block)
 
   # Merge hashes from multiple layer of hierarchy in hiera
   $hiera_options = hiera_hash("${module_name}::server::options", undef)
+  $hiera_match_block = hiera_hash("${module_name}::server::match_block", undef)
+
+  $fin_match_block = $hiera_match_block ? {
+    undef   => $match_block,
+    ''      => $match_block,
+    default => $hiera_match_block,
+  }
 
   $fin_options = $hiera_options ? {
     undef   => $options,
@@ -49,4 +59,6 @@ class ssh::server(
     Class['ssh::server::service'] ->
     Anchor['ssh::server::end']
   }
+  
+  create_resources('::ssh::server::match_block', $fin_match_block)
 }


### PR DESCRIPTION
Allowing the _ssh::server::match_block:_ options to be sent in the same way ssh:server::options can be set (when using _include ssh::server_ and
not including the entire ssh class) when using Hiera.  Options worked fine (as in issue below), but match_block was missing

See [https://github.com/saz/puppet-ssh/issues/194](url) for better explanation

(Tried to keep the code matching the other example in saz-ssh/manifests/init.pp)